### PR TITLE
Add privacy provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,45 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for block_fbcomments.
+ *
+ * @package    block_fbcomments
+ * @copyright  2023 Catalyst IT Australia Pty Ltd
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_fbcomments\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy Subsystem for block_fbcomments implementing null_provider.
+ */
+class provider implements null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/block_fbcomments.php
+++ b/lang/en/block_fbcomments.php
@@ -60,6 +60,7 @@ $string['newfbblock'] = 'Facebook comments';
 $string['notnumeric'] = 'This field must be numeric';
 $string['numposts'] = 'Number of comments to show';
 $string['pluginname'] = 'Facebook comments';
+$string['privacy:metadata'] = 'The Facebook comments block does not store user information on the Moodle site.';
 $string['reverse_time'] = 'Reverse time commented';
 $string['siteroot'] = 'Content for whole site';
 $string['social'] = 'Social';


### PR DESCRIPTION
Hello,

This pull request implements the null provider from the privacy API.

https://moodledev.io/docs/apis/subsystems/privacy

This is needed for our CI tests to pass and it is standard practice for modern plugins.

Looking forward to your response. Let me know if you have any questions or feedback.

